### PR TITLE
chore: List files to be published to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "build": "babel src --out-dir dist",
     "watch": "babel --watch src --out-dir dist"
   },
+  "files": [
+    "dist",
+    "client.js"
+  ],
   "dependencies": {
     "@babel/runtime": "7.12.5",
     "stripe": "8.132.0"


### PR DESCRIPTION
Override `.gitignore` using [`files`](https://docs.npmjs.com/cli/v6/configuring-npm/package-json#files) field in `package.json`