### PR TITLE
feat: Add confirmPaymentIntent

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,16 @@ const session = await createPaymentIntent({
 })
 ```
 
+#### Confirm
+
+```js
+import { confirmPaymentIntent } from 'next-stripe/client'
+
+const session = await confirmPaymentIntent('pi_id', {
+  payment_method: 'pm_id'
+})
+```
+
 #### Update
 
 ```js

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,5 +1,13 @@
 import fetcher from '../lib/fetcher'
 
+async function confirmPaymentIntent(id, body) {
+  return await fetcher({
+    body: { id, body },
+    method: 'POST',
+    url: `/api/stripe/confirm/payment-intent`
+  })
+}
+
 async function createCheckoutSession(body) {
   return await fetcher({
     body,

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -8,7 +8,12 @@ async function NextStripeHandler(req, res, options) {
 
   const [method, type] = req.query.nextstripe
 
-  if (method === 'create') {
+  if (method === 'confirm') {
+    switch (type) {
+      case 'payment-intent':
+        return routes.confirmPaymentIntent(req, res, options)
+    }
+  } else if (method === 'create') {
     switch (type) {
       case 'checkout-session':
         return routes.createCheckoutSession(req, res, options)

--- a/src/server/routes/confirm/payment-intent.js
+++ b/src/server/routes/confirm/payment-intent.js
@@ -1,0 +1,15 @@
+import Stripe from 'stripe'
+
+export default async function confirmPaymentIntent(req, res, options) {
+  try {
+    const stripe = new Stripe(options.secret_key)
+
+    const { id, body } = req.body
+
+    const paymentIntent = await stripe.paymentIntents.confirm(id, body)
+
+    res.status(201).json(paymentIntent)
+  } catch ({ statusCode, raw: { message } }) {
+    res.status(statusCode).json({ message, status: statusCode })
+  }
+}

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -1,3 +1,5 @@
+// Confirm
+export { default as confirmPaymentIntent } from './confirm/payment-intent'
 // Create
 export { default as createCheckoutSession } from './create/checkout-session'
 export { default as createPaymentIntent } from './create/payment-intent'


### PR DESCRIPTION
Adds a `confirmPaymentIntent` function and route handler to confirm a [PaymentIntent](https://stripe.com/docs/api/payment_intents).