### PR TITLE
feat: simplify NextStripe initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,9 @@ Create a `[...nextstripe].js` catch-all route in your project's `pages/api/strip
 ```js
 import NextStripe from 'next-stripe'
 
-const options = {
+export default NextStripe({
   secret_key: process.env.STRIPE_SECRET_KEY
-}
-
-export default (req, res) => NextStripe(req, res, options)
+})
 ```
 
 ## Usage

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -35,8 +35,10 @@ async function NextStripeHandler(req, res, options) {
   }
 }
 
-function NextStripe(...args) {
+export default function NextStripe (...args) {
+  if (args.length === 1) {
+    return (req, res) => NextStripeHandler(req, res, args[0])
+  }
+
   return NextStripeHandler(...args)
 }
-
-export default NextStripe


### PR DESCRIPTION
This is similar to what we did in NextAuth.js, see https://github.com/nextauthjs/next-auth/issues/868

Makes possible to do this:
```js
export default NextStripe(options)
```

instead of:
```js
export default (req, res) => NextStripe(req, res, options)
```

It is fully backward compatible with the old initialization.

I can update the docs if you are interested. 🙂

In the README.md, it could simply read:

```js
import NextStripe from 'next-stripe'

export default NextStripe({
  secret_key: process.env.STRIPE_SECRET_KEY
})
```