### PR TITLE
refactor: Recommend using restricted API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,13 @@ yarn add next-stripe@beta
 
 Create a `[...nextstripe].js` catch-all route in your project's `pages/api/stripe` directory.
 
+> ⚠️ PLEASE NOTE: It is recommended you use a [restricted key](https://stripe.com/docs/keys#limit-access) with limited API access with this library.
+
 ```js
 import NextStripe from 'next-stripe'
 
 export default NextStripe({
-  secret_key: process.env.STRIPE_SECRET_KEY
-})
+  stripe_key: process.env.STRIPE_RESTRICTED_KEY
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ yarn add next-stripe@beta
 
 Create a `[...nextstripe].js` catch-all route in your project's `pages/api/stripe` directory.
 
-> ⚠️ PLEASE NOTE: It is recommended you use a [restricted key](https://stripe.com/docs/keys#limit-access) with limited API access with this library.
+> ⚠️ PLEASE NOTE: It is recommended you use a [restricted key](https://stripe.com/docs/keys#limit-access) with limited API access with this library. These keys can be created and configured with the required access in the Stripe Dashboard.
 
 ```js
 import NextStripe from 'next-stripe'

--- a/src/server/routes/confirm/payment-intent.js
+++ b/src/server/routes/confirm/payment-intent.js
@@ -2,7 +2,7 @@ import Stripe from 'stripe'
 
 export default async function confirmPaymentIntent(req, res, options) {
   try {
-    const stripe = new Stripe(options.secret_key)
+    const stripe = new Stripe(options.stripe_key)
 
     const { id, body } = req.body
 

--- a/src/server/routes/create/billing-portal-session.js
+++ b/src/server/routes/create/billing-portal-session.js
@@ -2,7 +2,7 @@ import Stripe from 'stripe'
 
 export default async function createBillingPortalSession(req, res, options) {
   try {
-    const stripe = new Stripe(options.secret_key)
+    const stripe = new Stripe(options.stripe_key)
 
     const session = await stripe.billingPortal.sessions.create(req.body)
 

--- a/src/server/routes/create/checkout-session.js
+++ b/src/server/routes/create/checkout-session.js
@@ -2,7 +2,7 @@ import Stripe from 'stripe'
 
 export default async function createCheckoutSession(req, res, options) {
   try {
-    const stripe = new Stripe(options.secret_key)
+    const stripe = new Stripe(options.stripe_key)
 
     const session = await stripe.checkout.sessions.create(req.body)
 

--- a/src/server/routes/create/payment-intent.js
+++ b/src/server/routes/create/payment-intent.js
@@ -2,7 +2,7 @@ import Stripe from 'stripe'
 
 export default async function createPaymentIntent(req, res, options) {
   try {
-    const stripe = new Stripe(options.secret_key)
+    const stripe = new Stripe(options.stripe_key)
 
     const paymentIntent = await stripe.paymentIntents.create(req.body)
 

--- a/src/server/routes/retrieve/payment-intent.js
+++ b/src/server/routes/retrieve/payment-intent.js
@@ -2,7 +2,7 @@ import Stripe from 'stripe'
 
 export default async function retrievePaymentIntent(req, res, options) {
   try {
-    const stripe = new Stripe(options.secret_key)
+    const stripe = new Stripe(options.stripe_key)
 
     const paymentIntent = await stripe.paymentIntents.retrieve(req.body.id)
 

--- a/src/server/routes/update/payment-intent.js
+++ b/src/server/routes/update/payment-intent.js
@@ -2,7 +2,7 @@ import Stripe from 'stripe'
 
 export default async function updatePaymentIntent(req, res, options) {
   try {
-    const stripe = new Stripe(options.secret_key)
+    const stripe = new Stripe(options.stripe_key)
 
     const { id, body } = req.body
 


### PR DESCRIPTION
This PR updates documentation to recommend using a [restricted API key](https://stripe.com/docs/keys#limit-access).

Updated the `secret_key` parameter name to be `stripe_key` to reflect this change.

Fixes #22.